### PR TITLE
Add VerifyToken function to verify a standalone token

### DIFF
--- a/hcaptcha.go
+++ b/hcaptcha.go
@@ -105,31 +105,9 @@ func (c *Client) SiteVerify(r *http.Request) (response Response) {
 		return
 	}
 
-	resp, err := c.HTTPClient.PostForm(apiURL,
-		url.Values{
-			"secret":   {c.secret},
-			"response": {generatedResponseID},
-		},
-	)
-	if err != nil {
-		response.ErrorCodes = append(response.ErrorCodes, err.Error())
-		return
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		response.ErrorCodes = append(response.ErrorCodes, err.Error())
-		return
-	}
-
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		response.ErrorCodes = append(response.ErrorCodes, err.Error())
-		return
-	}
-
-	return
+	// Call VerifyToken for verification after extracting token
+	// Check token before call to maintain backwards compatibility
+	return c.VerifyToken(generatedResponseID)
 }
 
 // VerifyToken accepts a token and a secret key (https://dashboard.hcaptcha.com/settings).


### PR DESCRIPTION
Providing the ability to verify a standalone token could be advantageous in situations where one is using a custom API call with different parameters / uses a different transport method and extracts the token in their preferable way. Adding this functionality would make this much easier.

Side note: Consider adding custom error to response using the errors package, IMO, it makes it seem more clear

Signed-off-by: Sidharth Soni (Sid Sun) <sid@sidsun.com>