### PR TITLE
Add checks for remoteip and sitekey

### DIFF
--- a/hcaptcha.go
+++ b/hcaptcha.go
@@ -35,6 +35,12 @@ type Client struct {
 	// and without additional information.
 	FailureHandler http.Handler
 
+	// Optional checks for siteverify
+	// The user's IP address.
+	RemoteIP string
+	// The sitekey you expect to see.
+	SiteKey string
+
 	secret string
 }
 
@@ -121,12 +127,22 @@ func (c *Client) VerifyToken(tkn string) (response Response) {
 		return
 	}
 
-	resp, err := c.HTTPClient.PostForm(apiURL,
-		url.Values{
-			"secret":   {c.secret},
-			"response": {tkn},
-		},
-	)
+	values := url.Values{
+		"secret":   {c.secret},
+		"response": {tkn},
+	}
+
+	// Add remoteIP if set
+	if c.RemoteIP != "" {
+		values.Add("remoteip", c.RemoteIP)
+	}
+
+	// Add sitekey if set
+	if c.SiteKey != "" {
+		values.Add("sitekey", c.SiteKey)
+	}
+
+	resp, err := c.HTTPClient.PostForm(apiURL, values)
 	if err != nil {
 		response.ErrorCodes = append(response.ErrorCodes, err.Error())
 		return


### PR DESCRIPTION
The official documentation for hcaptcha includes optional parameters for [sitekey and remoteip](https://docs.hcaptcha.com/#verify-the-user-response-server-side)

This PR enables this optional parameters to be passed and used for hcaptcha response verification which would be very beneficial for my use case. Please let me know if there's anything I can do to improve my PR.